### PR TITLE
add pause/resume feat for queue details page, redis docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+redis:
+  image: redis:3.2
+  ports:
+    - '6381:6379'

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -5,6 +5,42 @@ $(document).ready(() => {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
 
+  $('.js-pause-queue').on('click', function(e) {
+    e.preventDefault();
+    $(this).prop('disabled', true);
+
+    const queueName = $(this).data('queue-name');
+    const queueHost = $(this).data('queue-host');
+
+    $.ajax({
+      method: 'POST',
+      url: `${basePath}/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/pause`
+    }).done(() => {
+      window.location.reload();
+    }).fail((jqXHR) => {
+      window.alert(`Failed to pause, check console for error.`);
+      console.error(jqXHR.responseText);
+    }); 
+  });
+
+  $('.js-resume-queue').on('click', function(e) {
+    e.preventDefault();
+    $(this).prop('disabled', true);
+
+    const queueName = $(this).data('queue-name');
+    const queueHost = $(this).data('queue-host');
+
+    $.ajax({
+      method: 'POST',
+      url: `${basePath}/api/queue/${encodeURIComponent(queueHost)}/${encodeURIComponent(queueName)}/resume`
+    }).done(() => {
+      window.location.reload();
+    }).fail((jqXHR) => {
+      window.alert(`Failed to resume, check console for error.`);
+      console.error(jqXHR.responseText);
+    }); 
+  });
+
   // Set up individual "retry job" handler
   $('.js-retry-job').on('click', function(e) {
     e.preventDefault();

--- a/src/server/views/api/index.js
+++ b/src/server/views/api/index.js
@@ -4,10 +4,15 @@ const jobRetry = require('./jobRetry');
 const jobRemove = require('./jobRemove');
 const bulkJobsRemove = require('./bulkJobsRemove');
 const bulkJobsRetry = require('./bulkJobsRetry');
+const queuePause = require('./queuePause');
+const queueResume = require('./queueResume');
 
 router.post('/queue/:queueHost/:queueName/job/bulk', bulkJobsRemove);
 router.patch('/queue/:queueHost/:queueName/job/bulk', bulkJobsRetry);
 router.patch('/queue/:queueHost/:queueName/job/:id', jobRetry);
 router.delete('/queue/:queueHost/:queueName/job/:id', jobRemove);
+
+router.post('/queue/:queueHost/:queueName/pause', queuePause);
+router.post('/queue/:queueHost/:queueName/resume', queueResume);
 
 module.exports = router;

--- a/src/server/views/api/queuePause.js
+++ b/src/server/views/api/queuePause.js
@@ -1,0 +1,20 @@
+async function handler(req, res) {
+  const { queueName, queueHost } = req.params;
+
+  const {Queues} = req.app.locals;
+  const queue = await Queues.get(queueName, queueHost);
+  if (!queue) return res.status(404).send({error: 'queue not found'});
+
+  try {
+    await queue.pause();
+    return res.sendStatus(200);
+  } catch (e) {
+    const body = {
+      error: 'queue error',
+      details: e.stack
+    };
+    return res.status(500).send(body);
+  }
+}
+
+module.exports = handler;

--- a/src/server/views/api/queueResume.js
+++ b/src/server/views/api/queueResume.js
@@ -1,0 +1,20 @@
+async function handler(req, res) {
+  const { queueName, queueHost } = req.params;
+
+  const {Queues} = req.app.locals;
+  const queue = await Queues.get(queueName, queueHost);
+  if (!queue) return res.status(404).send({error: 'queue not found'});
+
+  try {
+    await queue.resume();
+    return res.sendStatus(200);
+  } catch (e) {
+    const body = {
+      error: 'queue error',
+      details: e.stack
+    };
+    return res.status(500).send(body);
+  }
+}
+
+module.exports = handler;

--- a/src/server/views/dashboard/templates/queueDetails.hbs
+++ b/src/server/views/dashboard/templates/queueDetails.hbs
@@ -1,4 +1,12 @@
-<h2>Queue <code>{{ queueHost }}/{{ queueName }}</code></h2>
+<h2>
+  Queue <code>{{ queueHost }}/{{ queueName }}</code>
+  <button class="btn btn-default js-pause-queue" data-queue-host="{{ queueHost }}" data-queue-name="{{ queueName }}">
+    Pause
+  </button>
+  <button class="btn btn-success js-resume-queue" data-queue-host="{{ queueHost }}" data-queue-name="{{ queueName }}">
+    Resume
+  </button>  
+</h2>
 
 <h3>Job Types</h3>
 <div class="row">


### PR DESCRIPTION
This adds pause/resume for queues in bull arena (my fork). Sadly there isn't easy api access to whether a queue is currently paused or not but we should see the state of the job counts change.

<img width="1109" alt="screen shot 2018-12-13 at 11 18 11 am" src="https://user-images.githubusercontent.com/710752/49955931-a2528a00-fec9-11e8-97ec-df026ec4de84.png">

// cc @rowno @nettofarah